### PR TITLE
Allow for code splitting and dynamic imports + add some good libs

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -7,7 +7,10 @@ module.exports = {
   plugins: ['react-hot-loader/babel', '@babel/plugin-syntax-dynamic-import'],
   env: {
     test: {
-      plugins: ['@babel/transform-modules-commonjs'],
+      plugins: [
+        '@babel/transform-modules-commonjs',
+        'babel-plugin-dynamic-import-node',
+      ],
     },
   },
 }

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -4,9 +4,7 @@ module.exports = {
     '@babel/preset-react',
     ['@babel/preset-typescript', { isTSX: true, allExtensions: true }],
   ],
-  plugins: [
-    'react-hot-loader/babel'
-  ],
+  plugins: ['react-hot-loader/babel', '@babel/plugin-syntax-dynamic-import'],
   env: {
     test: {
       plugins: ['@babel/transform-modules-commonjs'],

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "types": "./types.d.ts",
   "dependencies": {
     "@babel/core": "^7.1.0",
+    "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-transform-modules-commonjs": "^7.1.0",
     "@babel/polyfill": "^7.0.0",
     "@babel/preset-env": "^7.1.0",

--- a/template/createProject/package.json
+++ b/template/createProject/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.1.0",
+    "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.1.0",
@@ -36,6 +37,7 @@
     "@types/react": "^16.4.14",
     "@types/react-dom": "^16.0.7",
     "@types/react-hot-loader": "^4.1.0",
+    "constate": "^0.8.2",
     "emotion": "^9.2.10",
     "emotion-server": "^9.2.10",
     "koa": "^2.5.3",
@@ -44,6 +46,7 @@
     "react-dom": "^16.5.2",
     "react-emotion": "^9.2.10",
     "react-hot-loader": "^4.3.11",
+    "react-lifecycle-components": "^1.1.1",
     "source-map-support": "^0.5.9",
     "typescript": "^3.0.3"
   },

--- a/template/createProject/package.json
+++ b/template/createProject/package.json
@@ -17,6 +17,7 @@
     "@types/jest": "^23.3.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
+    "babel-plugin-dynamic-import-node": "^2.1.0",
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",
     "husky": "^0.14.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "module": "es6",
+    "target": "esnext",
+    "module": "esnext",
     "lib": ["dom", "es6", "es7"],
     "jsx": "react",
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -243,6 +243,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-dynamic-import@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.0.0.tgz#6dfb7d8b6c3be14ce952962f658f3b7eb54c33ee"
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-syntax-json-strings@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.0.0.tgz#0d259a68090e15b383ce3710e01d5b23f3770cbd"


### PR DESCRIPTION
allow for use of `import('./my-heavy-component')`