### PR TITLE
Remove tslint no-implicit-dependencies

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -5,7 +5,6 @@
     "prettier": true,
     "object-literal-sort-keys": false,
     "interface-name": false,
-    "no-submodule-imports": false,
-    "no-implicit-dependencies": [true, ["enzyme"]]
+    "no-submodule-imports": false
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     "prettier": true,
     "object-literal-sort-keys": false,
     "interface-name": false,
-    "no-submodule-imports": false
+    "no-submodule-imports": false,
+    "no-implicit-dependencies": false
   }
 }


### PR DESCRIPTION
TSC should catch most of the errors and it kind of ruins it when you have a module directory like #11 enabled us to do hehe